### PR TITLE
PDFへの表実装について

### DIFF
--- a/lib/pdf/practice_pdf/post_pdf.rb
+++ b/lib/pdf/practice_pdf/post_pdf.rb
@@ -37,19 +37,30 @@ module PracticePdf
     end
     
     def body
-      
-      bounding_box([10, 450], width: 200, heigh:10 ) do
-        @schedules.each {|f| text f.client, size:10}
-      end
-      bounding_box([200, 450], width: 200, heigh:10) do
+      rows = [["訪問日","会社名","担当", "商談内容","目的","時間", "商品", "報告","次回"]]
+
+      bounding_box([200, 450], width: 500) do
         if @schedules.each do |f|
-            text f.person,size:10 
+          row_data = [
+            [
+              f.visit_date.strftime("%Y/%m/%d"),
+              f.client ? f.client : "",
+              f.person ? f.person: "",
+              f.content.name ? f.content.name : "",
+              f.aim ? f.aim : "",
+              (f.starting_time ? f.starting_time.strftime("%H:%M:%S") : "-") + "〜" + (f.ending_time ? f.ending_time.strftime("%H:%M:%S")  : "-"),
+              f.product.name ? f.product.name : "",
+              f.report ? f.report : "",
+              f.visit_date.strftime("%Y/%m/%d")
+            ]
+          ]
+          rows = rows + row_data
         end.empty?
-            text "itemの中身はありませんでした。"
+          text ""
         end
+        Rails.logger.info(rows)
+        table rows
       end
     end
-    
-    
   end
 end


### PR DESCRIPTION
表の実装サンプルです。

表を実装するには以下のようにします。

```
table row
```

で、このrowですが

```
row = [
    [配列1の値1, 配列1の値2, 配列1の値3, ...],
    [配列2の値1, 配列2の値2, 配列2の値2, ...],
    [配列3の値1, 配列3の値2,配列3の値3, ... ]
]
```
のような二次元配列にすると、

|配列1の値1|配列1の値2|配列1の値3|
|----|----|----|
|配列2の値1|配列2の値2|配列2の値3|
|配列3の値1|配列3の値2|配列3の値3|

上記のようなテーブルにしてくれることを利用して
row を生成していけばよいということです。

こちらが参考になります：https://qiita.com/ayies128/items/7262b771fdae5b7f0098#%E3%82%B5%E3%83%B3%E3%83%97%E3%83%AB